### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -88,5 +88,5 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 
-# xUnit1013: Public method should be marked as test
+# xUnit1013: Public method should be marked as test. Allows using records as test classes
 dotnet_diagnostic.xUnit1013.severity = none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - code-of-conduct.md
       - security.md
       - support.md
+      - readme.md
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -31,16 +32,13 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ⚙ dotnet 6.0.x
+      - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
-          include-prerelease: true
+          dotnet-version: '6.0.x'
 
       - name: ✓ ensure format
-        run: |
-          dotnet restore
-          dotnet format --verify-no-changes -v:diag
+        run: dotnet format --verify-no-changes -v:diag --exclude ~/.nuget
 
   build:
     name: build-${{ matrix.os }}
@@ -48,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [windows-latest, ubuntu-latest, macOS-latest]
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
@@ -56,11 +54,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ⚙ dotnet 6.0.x
+      - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
+        if: matrix.os != 'windows-latest'
         with:
-          dotnet-version: 6.0.x
-          include-prerelease: true
+          dotnet-version: '6.0.x'
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
@@ -72,34 +70,7 @@ jobs:
           echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
-        shell: bash --noprofile --norc {0}
-        env:
-          LC_ALL: en_US.utf8
-        run: |
-          [ -f .bash_profile ] && source .bash_profile
-          counter=0
-          exitcode=0
-          reset="\e[0m"
-          warn="\e[0;33m"
-          while [ $counter -lt 6 ]
-          do
-              if [ $filter ]
-              then
-                  echo -e "${warn}Retry $counter for $filter ${reset}"
-              fi
-              # run test and forward output also to a file in addition to stdout (tee command)
-              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
-              # capture dotnet test exit status, different from tee
-              exitcode=${PIPESTATUS[0]}
-              if [ $exitcode == 0 ]
-              then
-                  exit 0
-              fi
-              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
-              ((counter++))
-          done
-          exit $exitcode
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,9 +24,14 @@ jobs:
           ref: main
           token: ${{ env.GH_TOKEN }}
 
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+
       - name: ⚙ changelog
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -1,4 +1,4 @@
-﻿# Synchronizes .netconfig-configured files with dotnet-file
+# Synchronizes .netconfig-configured files with dotnet-file
 name: dotnet-file
 on:
   workflow_dispatch:
@@ -22,6 +22,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
 
+      - name: ⌛ rate
+        shell: pwsh
+        run: |
+          # add random sleep since we run on fixed schedule
+          sleep (get-random -max 60)
+          # get currently authenticated user rate limit info
+          $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+          # if we don't have at least 100 requests left, wait until reset
+          if ($rate.remaining -lt 10) {
+              $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
+              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              sleep $wait
+              $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+              echo "Rate limit has reset to $($rate.remaining) requests"
+          }
+
       - name: 🤘 checkout
         uses: actions/checkout@v2
         with:
@@ -30,6 +46,7 @@ jobs:
           token: ${{ env.GH_TOKEN }}
 
       - name: 🔄 sync
+        shell: pwsh
         run: |
           dotnet tool update -g dotnet-gcm
           dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
@@ -53,7 +70,7 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
-          commit-message: Bump files with dotnet-file sync
+          commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
           title: "Bump files with dotnet-file sync"

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -1,0 +1,28 @@
+name: +M▼ includes
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**.md'    
+
+jobs:
+  includes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v2
+
+      - name: +M▼ includes
+        uses: devlooped/actions-include@v4
+
+      - name: ✍ pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          branch: markdown-includes
+          delete-branch: true
+          commit-message: +M▼ includes
+          title: +M▼ includes
+          body: +M▼ includes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,51 +20,17 @@ jobs:
         with: 
           submodules: recursive
           fetch-depth: 0
-          
-      - name: ⚙ dotnet 6.0.x
+
+      - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
-          include-prerelease: true
+          dotnet-version: '6.0.x'
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
 
-      - name: ⚙ GNU grep
-        if: matrix.os == 'macOS-latest'
-        run: |
-          brew install grep
-          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
-
       - name: 🧪 test
-        shell: bash --noprofile --norc {0}
-        env:
-          LC_ALL: en_US.utf8
-        run: |
-          [ -f .bash_profile ] && source .bash_profile
-          counter=0
-          exitcode=0
-          reset="\e[0m"
-          warn="\e[0;33m"
-          while [ $counter -lt 6 ]
-          do
-              if [ $filter ]
-              then
-                  echo -e "${warn}Retry $counter for $filter ${reset}"
-              fi
-              # run test and forward output also to a file in addition to stdout (tee command)
-              dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
-              # capture dotnet test exit status, different from tee
-              exitcode=${PIPESTATUS[0]}
-              if [ $exitcode == 0 ]
-              then
-                  exit 0
-              fi
-              # cat output, get failed test names, join as DisplayName=TEST with |, remove trailing |.
-              filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)\w*' | awk 'BEGIN { ORS="|" } { print("DisplayName=" $0) }' | grep -o -P '.*(?=\|$)')
-              ((counter++))
-          done
-          exit $exitcode
+        uses: ./.github/workflows/test
 
       - name: 📦 pack
         run: dotnet pack -m:1 -p:version=${GITHUB_REF#refs/*/v}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,16 +20,21 @@ jobs:
       - name: 🏷 since
         run: echo "SINCE_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))" >> $GITHUB_ENV
 
+      - name: ⚙ ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+
       - name: ⚙ changelog
         if: env.SINCE_TAG != ''
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --since-tag ${{ env.SINCE_TAG }} --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: ⚙ changelog
         if: env.SINCE_TAG == ''
         run: |
-          sudo gem install github_changelog_generator 
+          gem install github_changelog_generator 
           github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🖉 release

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: 🔽 gh 
         run: |
-          iwr -useb get.scoop.sh | iex
+          iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           scoop install gh
 
       - name: 💛 sponsors

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,0 +1,36 @@
+name: test
+description: runs dotnet tests with retry
+runs:
+  using: "composite"
+  steps:
+    - name: 🧪 test
+      shell: bash --noprofile --norc {0}
+      env:
+        LC_ALL: en_US.utf8
+      run: |
+        [ -f .bash_profile ] && source .bash_profile
+        counter=0
+        exitcode=0
+        reset="\e[0m"
+        warn="\e[0;33m"
+        while [ $counter -lt 6 ]
+        do
+            # run test and forward output also to a file in addition to stdout (tee command)
+            if [ $filter ]
+            then
+                echo -e "${warn}Retry $counter for $filter ${reset}"
+                dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m --filter=$filter | tee ./output.log
+            else
+                dotnet test --no-build -m:1 --blame-hang --blame-hang-timeout 5m | tee ./output.log
+            fi
+            # capture dotnet test exit status, different from tee
+            exitcode=${PIPESTATUS[0]}
+            if [ $exitcode == 0 ]
+            then
+                exit 0
+            fi
+            # cat output, get failed test names, remove trailing whitespace, sort+dedupe, join as FQN~TEST with |, remove trailing |.
+            filter=$(cat ./output.log | grep -o -P '(?<=\sFailed\s)[\w\._]*' | sed 's/ *$//g' | sort -u | awk 'BEGIN { ORS="|" } { print("FullyQualifiedName~" $0) }' | grep -o -P '.*(?=\|$)')
+            ((counter++))
+        done
+        exit $exitcode

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,12 @@ TestResults
 *.nupkg
 *.metaproj
 *.tmp
+*.log
 *.cache
 *.binlog
 *.zip
+__azurite*.*
+__*__
 
 .nuget
 *.lock.json

--- a/.netconfig
+++ b/.netconfig
@@ -24,8 +24,8 @@
 	skip
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	sha = 0683ee777d7d878d4bf013d7deea352685135a05
-	etag = 985aa022503959d35b03c870f07ae604cead7580d260775235ef6665aa9a6cbe
+	sha = 369cd2bd49ce032f616a2fcb4c997535dbe8d9aa
+	etag = 4e857df48d0abd81512350d6b3b1a1c83b78284be65bd5172a4ec8e52cd04e2d
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -49,33 +49,33 @@
 	weak
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
-	etag = ef5ed75b1e23292dd7af196a11f04760aa5ad4a3f374095395da9abc2de3f24f
+	sha = e19ed3228a0ac7f64a43197241a788fb224a683f
+	etag = 4e65025ab77d15766520234d3a9953ff4f1eea91620e1080f10909de19804877
 	weak
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
-	etag = 99c02f817f1a2b6ffaec4f7c4cd1c60e6bfae966174568f8027a4a2f42a00e69
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
+	etag = 202803313c2792cb09d9cb8041fe4b39e550e26c90971a57b92534c599a596a7
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 084aa7c36ee1c262ea2f9e83931068366a7b4312
-	etag = 501f8bf58287fdd7467701342f7251a015bc29664b494e7d81a71c0c55bee61f
+	sha = ef47d782b45dbf3dc7f47f39168a2eed9c536a40
+	etag = 41db5ebfb3f06bf2a9d55919f50a10fa80057a0d636532beac3b77464c3c1b5d
 	weak
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	sha = 964caa363fe9cd8ef01c8a5d8e3fd07d1aed35ae
-	etag = d6369e92c55eb78322ff39d26fc4ef1996b691a8ce05392395ab393e14ddb940
+	sha = 0e5a33cc685fa85e3a81b797202f3e14e1cd84a9
+	etag = 1d6a05b7f684b4fc1bb387750b0e100406e8a0017981c4e9d39a012479f35266
 	weak
 [file ".github/workflows/release-notes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-notes.yml
-	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
-	etag = f9e85892ecefdc98584d9a90c3b29e63e910f161b8761a51eaeb94dfa9bd3e4f
+	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
+	etag = d1de9cb9c403ed8632d22d4cc153ae63b075266b9ce638b9ac73fd47dd2bccc1
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = a9f9d3f5db6dd0714f52da61e35ab233fd0a1642
-	etag = e6ba96dc8c185a4e9c64f7c2c8003ef86e8f73624865ff7f6ae955aad55a164e
+	sha = c78868eba59a3e04602434684f9eac241fef13fb
+	etag = 1c1705a3f0ed65e33c9133996ebaa100aa445a8b968b2904ad48fef938702006
 	weak
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
@@ -109,13 +109,13 @@
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = e2606657b68d2980cc3cae181c59baa3d847ab75
-	etag = a44fa4e71022b1c5f9684ec65815f69b47d51d0289e58bd9396606bd88e4244a
+	sha = 2fea462dc563923800a7efad24a52aa0541a8864
+	etag = 819e24ed16c1257f3c6ea3c728e1507020bacf32aeb63f5dd56f9a5cb2652275
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = bfe0f2a2a668878931f43b7280f0406a2171ff0c
-	etag = 46287392cb21e28595b1ea658236b8afa15f985c9f75dc08ed85e81a2c465755
+	sha = b9fb0a7d34d6c16fb404f9dff4aac6789ef08a00
+	etag = 852b16129d2c681ad6ec86ff56b256541e0ce0961eb3a9492e0ead89ffe5a6bd
 	weak
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
@@ -139,8 +139,8 @@
 	weak
 [file ".github/workflows/sponsors.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.yml
-	sha = 514760df24bd906b9e5d3a56deac0d18cba59a6d
-	etag = 0236ed96c1d11f69b26ac0e039e74107df5731574236e2de2a83152fee5df0a6
+	sha = 8b6384e91fdfcf8f3cc9b3b262a9ca2a1095d06a
+	etag = 2c05a753600913f546c37a2ea9393b3ede3b6f8473e5c2d53462aa7342af7078
 	weak
 [file "Gemfile"]
 	url = https://github.com/devlooped/.github/blob/main/Gemfile
@@ -151,4 +151,29 @@
 	url = https://github.com/devlooped/oss/blob/main/.github/.github_changelog_generator
 	sha = b7ce2bedba3fe467b8bc252c372cd36bbde259a5
 	etag = 28145d505ce95b57628ab368bb12744300d5f539d3651c346e3c0c3f772ffa7b
+	weak
+[file ".github/workflows/includes.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
+	sha = 66caefba98939c5c0505ab536417aa4ec4eec240
+	etag = acdb356278d3f41cf3cd4620ff81d16caddd2571ccfee73f5a86ffbd4f8c9944
+	weak
+[file ".github/workflows/test/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
+	sha = 9a1b07589b9bde93bc12528e9325712a32dec418
+	etag = b54216ac431a83ce5477828d391f02046527e7f6fffd21da1d03324d352c3efb
+	weak
+[file "docs/footer.md"]
+	url = https://github.com/devlooped/oss/blob/main/docs/footer.md
+	sha = 56086e5645a50f8dc837bab919f7c12f6c50e070
+	etag = 6e45ba613fdc949a6a5d84ed8efd5cc1b36d13bb0fd965e206fd5e92b604e2d0
+	weak
+[file "docs/sponsors.md"]
+	url = https://github.com/devlooped/oss/blob/main/docs/sponsors.md
+	sha = 923ddc16dce95c591fe91059720b3447107ec57f
+	etag = 555eea0c0cd7014181709931752b99360405799579027d4dccf21975455561ab
+	weak
+[file "src/nuget.config"]
+	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
+	sha = 1537aa96d3c999642d678e1143b09950f235b977
+	etag = 754274e682c3523e3ac0a142ada64abff20551dc73bf16edfbd66415dcf87fd0
 	weak

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,0 +1,11 @@
+# Sponsors 
+
+<!-- include sponsors.md -->
+
+<br>&nbsp;
+<a href="https://github.com/sponsors/devlooped" title="Sponsor this project">
+  <img src="https://github.com/devlooped/sponsors/blob/main/sponsor.png" />
+</a>
+<br>
+
+[Learn more about GitHub Sponsors](https://github.com/sponsors)

--- a/docs/sponsors.md
+++ b/docs/sponsors.md
@@ -1,0 +1,25 @@
+<!-- sponsors -->
+
+<a href='https://github.com/KirillOsenkov'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/KirillOsenkov.svg' alt='Kirill Osenkov' title='Kirill Osenkov'>
+</a>
+<a href='https://github.com/augustoproiete'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/augustoproiete.svg' alt='C. Augusto Proiete' title='C. Augusto Proiete'>
+</a>
+<a href='https://github.com/sandrock'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/sandrock.svg' alt='SandRock' title='SandRock'>
+</a>
+<a href='https://github.com/aws'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/aws.svg' alt='Amazon Web Services' title='Amazon Web Services'>
+</a>
+<a href='https://github.com/MelbourneDeveloper'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/MelbourneDeveloper.svg' alt='Christian Findlay' title='Christian Findlay'>
+</a>
+<a href='https://github.com/clarius'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/clarius.svg' alt='Clarius Org' title='Clarius Org'>
+</a>
+<a href='https://github.com/MFB-Technologies-Inc'>
+  <img src='https://github.com/devlooped/sponsors/raw/main/.github/avatars/MFB-Technologies-Inc.svg' alt='MFB Technologies, Inc.' title='MFB Technologies, Inc.'>
+</a>
+
+<!-- sponsors -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,9 @@
     <!-- Use Directory.Packages.props if possible. NOTE: other MSBuild SDKs (i.e. NoTargets/Traversal) do not support central packages -->
     <ManagePackageVersionsCentrally Condition="Exists('$(MSBuildThisFileDirectory)Directory.Packages.props') AND ('$(MSBuildProjectExtension)' == '.csproj' OR '$(MSBuildProjectExtension)' == '.vbproj')">true</ManagePackageVersionsCentrally>
     <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;$(RestoreSources)</RestoreSources>
+
+    <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
+    <GeneratePathProperty>true</GeneratePathProperty>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -80,6 +83,9 @@
     
     <!-- Preserve transitively copied content in VS: https://github.com/dotnet/msbuild/issues/1054#issuecomment-847959047 -->
     <MSBuildCopyContentTransitively>true</MSBuildCopyContentTransitively>
+    
+    <!-- Global tools should run on whatever latest runtime is installed. See https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward -->
+    <RollForward>LatestMinor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">
@@ -124,6 +130,8 @@
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
+    <ProjectProperty Include="CI" />
+  
     <ProjectProperty Include="Version" />
     <ProjectProperty Include="VersionPrefix" />
     <ProjectProperty Include="VersionSuffix" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -109,8 +109,11 @@
 
   <ItemGroup>
     <!-- Make these available via ThisAssembly.Project -->
+    <ProjectProperty Include="RepositoryBranch" />
     <ProjectProperty Include="RepositorySha" />
     <ProjectProperty Include="RepositoryCommit" />
+    <ProjectProperty Include="RepositoryRoot" />
+    <ProjectProperty Include="RepositoryUrl" />
   </ItemGroup>
 
   <!-- Make sure the source control info is available before calling source generators -->
@@ -131,9 +134,17 @@
       <SourceRevisionId>$(RepositorySha)</SourceRevisionId>
     </PropertyGroup>
 
+    <!-- Add SourceRoot as a project property too -->
+    <ItemGroup>
+      <_GitSourceRoot Include="@(SourceRoot -> WithMetadataValue('SourceControl', 'git'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RepositoryRoot>@(_GitSourceRoot)</RepositoryRoot>
+    </PropertyGroup>
+
   </Target>
 
-  <!-- Always append the link to the direct source tree for the current build -->
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
           DependsOnTargets="EnsureProjectInformation"
@@ -141,10 +152,6 @@
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
       <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl)</PackageProjectUrl>
-      <Description Condition="'$(RepositorySha)' != '' and '$(RepositoryUrl)' != ''">$(Description)
-
-Built from $(RepositoryUrl)/tree/$(RepositorySha)
-      </Description>
       <PackageDescription>$(Description)</PackageDescription>
       <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl)/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>
@@ -152,55 +159,5 @@ Built from $(RepositoryUrl)/tree/$(RepositorySha)
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>
-
-  <!--
-  ==============================================================
-    DumpItems Task
-    Helper task useful for quickly inspecting the full metadata
-    of arbitrary items in any target.
-
-    Properties:
-    - Items: Microsoft.Build.Framework.ITaskItem[] (Input, Required)
-    - ItemName: string (Input, Optional)
-	==============================================================
-  -->
-  <UsingTask TaskName="DumpItems" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <Items ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      <ItemName />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="Microsoft.Build" />
-      <Reference Include="Microsoft.CSharp" />
-      <Reference Include="System" />
-      <Reference Include="System.Core" />
-      <Using Namespace="Microsoft.Build.Framework" />
-      <Using Namespace="Microsoft.Build.Utilities" />
-      <Using Namespace="System" />
-      <Using Namespace="System.Linq" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-			  var itemName = ItemName ?? "Item";
-			  if (Items.Length == 0)
-				  Log.LogMessage(MessageImportance.High, "No {0} items received to dump.", ItemName ?? "");
-			  else
-				  Log.LogMessage(MessageImportance.High, "Dumping {0} {1} items.", Items.Length, ItemName ?? "");
-
-			  foreach (var item in Items.OrderBy(i => i.ItemSpec))
-			  {
-				  Log.LogMessage(MessageImportance.High, "{0}: {1}", itemName, item.ItemSpec);
-				  foreach (var name in item.MetadataNames.OfType<string>().OrderBy(_ => _))
-				  {
-					  try
-					  {
-						  Log.LogMessage(MessageImportance.High, "\t{0}={1}", name, item.GetMetadata(name));
-					  }
-					  catch { }
-				  }
-			  }
-      ]]>
-      </Code>
-    </Task>
-  </UsingTask>
 
 </Project>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+      <add key="signatureValidationMode" value="accept" />
+    </config>
+    <trustedSigners>
+      <author name="Microsoft">
+        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </author>
+      <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint=" CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+        <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      </repository>
+    </trustedSigners>
+</configuration>


### PR DESCRIPTION
# devlooped/oss

- Bump to include action that disables nested includes https://github.com/devlooped/oss/commit/66caefb
- Fix initial test run without filter https://github.com/devlooped/oss/commit/9a1b075
- Remove a bit the space above the button https://github.com/devlooped/oss/commit/56086e5
- Add sponsors and footer to docs https://github.com/devlooped/oss/commit/923ddc1
- Revert "Add default package source mapping for central package versions" https://github.com/devlooped/oss/commit/1537aa9
- Ensure ruby v3 is installed for changelog generation https://github.com/devlooped/oss/commit/be8f625
- Add icon prefix to match dependabot https://github.com/devlooped/oss/commit/2a39a42
- Add rate limiting fix https://github.com/devlooped/oss/commit/ef47d78
- Reuse test with retries definition by using a composite action https://github.com/devlooped/oss/commit/3b9f317
- Now that .NET6 is LTS, ensure it's installed https://github.com/devlooped/oss/commit/7ebebbd
- Remove GNU grep step from publish since it runs ubuntu https://github.com/devlooped/oss/commit/0e5a33c
- Ignore azurite files https://github.com/devlooped/oss/commit/829faad
- Add azurite hidden folders too https://github.com/devlooped/oss/commit/978c71c
- Ignore *.log files https://github.com/devlooped/oss/commit/c78868e
- Global tools should run on whatever latest runtime is installed. https://github.com/devlooped/oss/commit/b65c8f1
- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] https://github.com/devlooped/oss/commit/cc6922f
- Add CI as a project property https://github.com/devlooped/oss/commit/2fea462
- Add RepositoryBranch as a ThisAssembly.Project property https://github.com/devlooped/oss/commit/83d7378
- Add RepositoryRoot property from source control information https://github.com/devlooped/oss/commit/f9763d3
- Add RepositoryUrl as project property, if available https://github.com/devlooped/oss/commit/4f57ffe
- Remove DumpItems task. Easily replaceable with MSBuild.DumpItems https://github.com/devlooped/oss/commit/024f733
- Ignore xUnit1013 so records can be used as test classes https://github.com/devlooped/oss/commit/369cd2b
- Remove the source link in the package description https://github.com/devlooped/oss/commit/b9fb0a7
- Switch to windows-latest agent which is now .NET6 https://github.com/devlooped/oss/commit/445239b
- Ignore nuget-provided files for formatting https://github.com/devlooped/oss/commit/bbf637b
- Ignore changes to readme.md as build trigger https://github.com/devlooped/oss/commit/e19ed32

# devlooped/.github

- Fix for installing gh as admin https://github.com/devlooped/.github/commit/8b6384e